### PR TITLE
Do not attempt to load an image if we can't recognize a Pokemon

### DIFF
--- a/assets/css/paste.css
+++ b/assets/css/paste.css
@@ -22,9 +22,13 @@ div.img {
 	-ms-user-select: none;
 }
 
-img.img-pokemon {
+.img-pokemon {
 	width: 150px;
 	height: 150px;
+}
+
+.img-stub {
+	height: 25px;
 }
 
 img.img-item {

--- a/paste.tmpl
+++ b/paste.tmpl
@@ -9,7 +9,11 @@
 	{{- range .Paste}}
 		<article>
 			<div class="img">
+			{{- if .Pokemon}}
 				<img class="img-pokemon" src="/img/pokemon/{{.Pokemon}}-{{.Form}}.png">
+			{{- else}}
+				<div class="img-pokemon img-stub" />
+			{{- end}}
 			{{- with .Item}}
 				<img class="img-item" src="/img/items/{{.}}.png">
 			{{- end}}


### PR DESCRIPTION
This is a very hackish workaround but it seems to get the job done. Before:

![before](https://user-images.githubusercontent.com/9159214/61669641-c28fc600-acae-11e9-89a2-af97c33e0377.PNG)

After:

![after](https://user-images.githubusercontent.com/9159214/61669650-ce7b8800-acae-11e9-86a7-d7adf0264338.PNG)

I couldn't figure out how to build the repo (I manually edited the HTML for the page to get the image above), so you may want to make sure it compiles before merging.